### PR TITLE
Add nationwide Facebook Marketplace search mode

### DIFF
--- a/app/api/search/facebook/nationwide/route.ts
+++ b/app/api/search/facebook/nationwide/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+import { chromium } from "playwright";
+import path from "path";
+import os from "os";
+import type { Listing } from "@/app/lib/types";
+import { NATIONWIDE_FB_CITIES } from "@/app/lib/cities";
+import { withPlaywrightLock } from "@/app/lib/playwright-lock";
+
+const BRAVE_USER_DATA = path.join(
+  os.homedir(),
+  "Library/Application Support/BraveSoftware/Brave-Browser"
+);
+const BRAVE_EXECUTABLE =
+  "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser";
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const keywords = searchParams.get("keywords") ?? "";
+  const minPrice = searchParams.get("minPrice") ?? "";
+  const maxPrice = searchParams.get("maxPrice") ?? "";
+
+  if (!keywords.trim()) {
+    return NextResponse.json({ listings: [], error: "keywords required" }, { status: 400 });
+  }
+
+  return withPlaywrightLock(async () => {
+    let browser;
+    try {
+      browser = await chromium.launchPersistentContext(BRAVE_USER_DATA, {
+        headless: true,
+        executablePath: BRAVE_EXECUTABLE,
+        args: [
+          "--no-sandbox",
+          "--disable-blink-features=AutomationControlled",
+          "--disable-dev-shm-usage",
+        ],
+        ignoreDefaultArgs: ["--enable-automation"],
+      });
+    } catch {
+      browser = await chromium.launchPersistentContext(
+        path.join(os.tmpdir(), "fb-marketplace-session"),
+        { headless: true, args: ["--no-sandbox", "--disable-dev-shm-usage"] }
+      );
+    }
+
+    const allListings: Listing[] = [];
+    const errors: string[] = [];
+
+    try {
+      const page = browser.pages()[0] ?? (await browser.newPage());
+      await page.addInitScript(() => {
+        Object.defineProperty(navigator, "webdriver", { get: () => undefined });
+      });
+
+      for (const [cityName, citySlug] of NATIONWIDE_FB_CITIES) {
+        try {
+          const params = new URLSearchParams({ query: keywords });
+          if (minPrice) params.set("minPrice", minPrice);
+          if (maxPrice) params.set("maxPrice", maxPrice);
+          // Use a wide radius to cover the metro area
+          params.set("exact_radius", "100");
+          params.set("radius_unit", "imperial");
+
+          const url = `https://www.facebook.com/marketplace/${citySlug}/search?${params}`;
+          await page.goto(url, { waitUntil: "domcontentloaded", timeout: 20000 });
+
+          // Dismiss login dialog
+          try {
+            await page.locator('[aria-label="Close"]').first().click({ timeout: 2000 });
+          } catch {}
+
+          // Wait for listings
+          try {
+            await page.waitForSelector('a[href*="/marketplace/item/"]', { timeout: 8000 });
+          } catch {
+            console.log(`[Nationwide] No listings found for ${cityName}, skipping`);
+            continue;
+          }
+
+          // Quick scroll to load a few listings
+          for (let s = 0; s < 3; s++) {
+            await page.evaluate(() => window.scrollBy(0, 1500));
+            await page.waitForTimeout(800);
+          }
+
+          // Extract listings
+          const cityListings: Listing[] = await page.evaluate((city: string) => {
+            const results: Listing[] = [];
+            const links = Array.from(document.querySelectorAll<HTMLAnchorElement>('a[href*="/marketplace/item/"]'));
+            const seen = new Set<string>();
+
+            for (const a of links) {
+              if (results.length >= 10) break;
+              const href = a.href.split("?")[0];
+              if (seen.has(href)) continue;
+              seen.add(href);
+
+              const img = a.querySelector<HTMLImageElement>("img");
+              const spans = Array.from(a.querySelectorAll("span"));
+
+              const priceSpan = spans.find((s) => s.textContent?.trim().startsWith("$"));
+              const priceText = priceSpan?.textContent?.trim() ?? "";
+              const priceMatch = priceText.match(/[\d,]+/);
+              const price = priceMatch ? parseFloat(priceMatch[0].replace(/,/g, "")) : null;
+
+              const titleSpan = spans
+                .filter((s) => !s.textContent?.startsWith("$") && (s.textContent?.length ?? 0) > 5)
+                .sort((a, b) => (b.textContent?.length ?? 0) - (a.textContent?.length ?? 0))[0];
+              const title = titleSpan?.textContent?.trim() ?? "Facebook Marketplace listing";
+
+              const locationSpan = spans.find(
+                (s) =>
+                  s !== priceSpan &&
+                  s !== titleSpan &&
+                  (s.textContent?.length ?? 0) > 2 &&
+                  (s.textContent?.length ?? 0) < 50
+              );
+
+              results.push({
+                id: `fb-${city}-${results.length}`,
+                title,
+                price,
+                imageUrl: img?.src ?? null,
+                location: locationSpan?.textContent?.trim() ?? city,
+                postedAt: null,
+                sourceUrl: href,
+                source: "facebook" as const,
+              });
+            }
+            return results;
+          }, cityName);
+
+          allListings.push(...cityListings);
+          console.log(`[Nationwide] ${cityName}: ${cityListings.length} listings`);
+
+          // Brief pause between cities to avoid rate limiting
+          await page.waitForTimeout(1500);
+        } catch (err) {
+          console.error(`[Nationwide] Error searching ${cityName}:`, err);
+          errors.push(`${cityName}: ${err instanceof Error ? err.message : "failed"}`);
+        }
+      }
+
+      // Deduplicate by source URL
+      const seen = new Set<string>();
+      const deduplicated = allListings.filter((l) => {
+        const key = l.sourceUrl.split("?")[0];
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+      // Sort by price
+      deduplicated.sort((a, b) => {
+        if (a.price == null && b.price == null) return 0;
+        if (a.price == null) return 1;
+        if (b.price == null) return -1;
+        return a.price - b.price;
+      });
+
+      console.log(`[Nationwide] Total: ${deduplicated.length} unique listings from ${NATIONWIDE_FB_CITIES.length} cities`);
+      return NextResponse.json({
+        listings: deduplicated,
+        rawCount: allListings.length,
+        citiesSearched: NATIONWIDE_FB_CITIES.length,
+        errors: errors.length > 0 ? errors : undefined,
+      });
+    } catch (err) {
+      console.error("Nationwide scrape error:", err);
+      return NextResponse.json({
+        listings: allListings,
+        error: `Nationwide search failed: ${err instanceof Error ? err.message : "unknown"}`,
+      });
+    } finally {
+      await browser.close();
+    }
+  });
+}

--- a/app/lib/cities.ts
+++ b/app/lib/cities.ts
@@ -110,3 +110,39 @@ export const CITY_TO_FB: Record<string, string> = {
   dc: "washington",
   "washington dc": "washington",
 };
+
+/**
+ * Representative cities spread across the US for nationwide Facebook search.
+ * Each entry is [displayName, fbSlug]. Covers major metro regions.
+ */
+export const NATIONWIDE_FB_CITIES: [string, string][] = [
+  ["New York", "nyc"],
+  ["Los Angeles", "la"],
+  ["Chicago", "chicago"],
+  ["Houston", "houston"],
+  ["Phoenix", "phoenix"],
+  ["Seattle", "seattle"],
+  ["Denver", "denver"],
+  ["Atlanta", "atlanta"],
+  ["Miami", "miami"],
+  ["Dallas", "dallas"],
+  ["Boston", "boston"],
+  ["Minneapolis", "minneapolis"],
+  ["Philadelphia", "philadelphia"],
+  ["Nashville", "nashville"],
+  ["Portland", "portland"],
+];
+
+/** Deduplicated, sorted city options for the browse page dropdown */
+export const FB_CITY_OPTIONS: { label: string; slug: string }[] = (() => {
+  const seen = new Set<string>();
+  const options: { label: string; slug: string }[] = [];
+  for (const [name, slug] of Object.entries(CITY_TO_FB)) {
+    if (seen.has(slug)) continue;
+    seen.add(slug);
+    // Capitalize each word for the label
+    const label = name.replace(/\b\w/g, (c) => c.toUpperCase());
+    options.push({ label, slug });
+  }
+  return options.sort((a, b) => a.label.localeCompare(b.label));
+})();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -40,6 +40,7 @@ export default function Home() {
 
   const [locationOverride, setLocationOverride] = useState("");
   const [radiusOverride, setRadiusOverride] = useState("");
+  const [nationwideMode, setNationwideMode] = useState(false);
 
   const [searchParams, setSearchParams] = useState<SearchParams | null>(null);
   const [categoryLabel, setCategoryLabel] = useState("");
@@ -156,7 +157,12 @@ export default function Home() {
       setClUrl(buildCraigslistUrl(params));
 
       // Step 2: Fetch eBay + Facebook Marketplace in parallel
-      setLoadingStep("Searching eBay & Facebook Marketplace...");
+      const isNationwide = nationwideMode && !params.location;
+      setLoadingStep(
+        isNationwide
+          ? "Searching eBay & Facebook Marketplace nationwide (this takes a while)..."
+          : "Searching eBay & Facebook Marketplace..."
+      );
 
       const ebayParams = new URLSearchParams({
         keywords: params.keywords,
@@ -173,9 +179,13 @@ export default function Home() {
         ...(params.radiusMiles ? { radiusMiles: String(params.radiusMiles) } : {}),
       });
 
+      const fbEndpoint = isNationwide
+        ? `/api/search/facebook/nationwide?${fbParams}`
+        : `/api/search/facebook?${fbParams}`;
+
       const [ebayResult, fbResult] = await Promise.allSettled([
         fetch(`/api/search/ebay?${ebayParams}`).then((r) => r.json()),
-        fetch(`/api/search/facebook?${fbParams}`).then((r) => r.json()),
+        fetch(fbEndpoint).then((r) => r.json()),
       ]);
 
       const allListings: Listing[] = [];
@@ -298,19 +308,35 @@ export default function Home() {
               value={locationOverride}
               onChange={(e) => setLocationOverride(e.target.value)}
               placeholder="Location (city or zip)"
-              className="px-3 py-2 rounded-lg border border-gray-700 bg-gray-800 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-48"
+              disabled={nationwideMode}
+              className="px-3 py-2 rounded-lg border border-gray-700 bg-gray-800 text-sm text-gray-100 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent w-48 disabled:opacity-40"
             />
             <select
               value={radiusOverride}
               onChange={(e) => setRadiusOverride(e.target.value)}
-              className="px-3 py-2 rounded-lg border border-gray-700 bg-gray-800 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent"
+              disabled={nationwideMode}
+              className="px-3 py-2 rounded-lg border border-gray-700 bg-gray-800 text-sm text-gray-100 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent disabled:opacity-40"
             >
               <option value="">Any distance</option>
               {RADIUS_OPTIONS.map((r) => (
                 <option key={r} value={r}>{r} miles</option>
               ))}
             </select>
+            <label className="flex items-center gap-2 cursor-pointer select-none">
+              <input
+                type="checkbox"
+                checked={nationwideMode}
+                onChange={(e) => setNationwideMode(e.target.checked)}
+                className="w-4 h-4 rounded accent-indigo-500"
+              />
+              <span className="text-sm text-gray-300 font-medium">Nationwide</span>
+            </label>
           </div>
+          {nationwideMode && (
+            <p className="mt-1 text-xs text-indigo-400">
+              Searches Facebook Marketplace across 15 major US cities. Takes longer (~2-3 min).
+            </p>
+          )}
 
           {!searchParams && (
             <div className="mt-3 flex flex-wrap gap-2">


### PR DESCRIPTION
## Summary
- New "Nationwide" toggle on the Used Finder page that searches Facebook Marketplace across 15 major US metro areas in a single search
- New API endpoint `/api/search/facebook/nationwide` that sequentially searches NYC, LA, Chicago, Houston, Phoenix, Seattle, Denver, Atlanta, Miami, Dallas, Boston, Minneapolis, Philadelphia, Nashville, and Portland
- Deduplicates listings across cities and sorts by price
- When enabled, disables the location/radius inputs (nationwide overrides them)

## Test plan
- [x] Verified toggle UI renders correctly with info text and disables location inputs
- [ ] Test a nationwide search end-to-end with Brave browser available
- [ ] Verify deduplication works across overlapping metro areas
- [ ] Confirm results show city/location for each listing

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)